### PR TITLE
<Text> Support For HTML h1-h6 Elements

### DIFF
--- a/.storybook/Text.js
+++ b/.storybook/Text.js
@@ -47,7 +47,7 @@ storiesOf('Text', module)
   ))
   .add('Using <h3> heading', () => (
     <div>
-      <Text color='purple'>Hello Blue</Text>
-      <Text color='orange'>Hello Green</Text>
+      <Text color='purple'>Hello Purple</Text>
+      <Text color='orange'>Hello Orange</Text>
     </div>
   ))

--- a/.storybook/Text.js
+++ b/.storybook/Text.js
@@ -45,3 +45,9 @@ storiesOf('Text', module)
       <Text color='green'>Hello Green</Text>
     </div>
   ))
+  .add('Using <h3> heading', () => (
+    <div>
+      <Text color='purple'>Hello Blue</Text>
+      <Text color='orange'>Hello Green</Text>
+    </div>
+  ))

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     {
       "name": "Malek Hakim",
       "email": "hakimelek@gmail.com"
+    },
+    {
+      "name": "Ben Chen",
+      "email": "benjaminlchen@gmail.com"
     }
   ],
   "license": "MIT",

--- a/src/Text.js
+++ b/src/Text.js
@@ -63,6 +63,12 @@ Text.propTypes = {
   py: numberStringOrArray
 }
 
+Text.h1 = Text.withComponent('h1')
+Text.h2 = Text.withComponent('h2')
+Text.h3 = Text.withComponent('h3')
+Text.h4 = Text.withComponent('h4')
+Text.h5 = Text.withComponent('h5')
+Text.h6 = Text.withComponent('h6')
 Text.span = Text.withComponent('span')
 Text.p = Text.withComponent('p')
 


### PR DESCRIPTION
Support HTML heading elements(i.e. h1-h6) using syntax such as:
```
<Text.h3 />
```

Relate to issue @ pricelinelabs/design-system#47
<img width="434" alt="text-headings" src="https://user-images.githubusercontent.com/6441326/29698784-2af8b228-8926-11e7-8caa-f1191a242d4b.png">
